### PR TITLE
Make enabled packet listeners configurable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,7 @@ repositories {
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.17-R0.1-SNAPSHOT")
     compileOnly("com.mojang:authlib:2.0.27")
-    compileOnly("com.comphenix.protocol:ProtocolLib:4.7.0-SNAPSHOT")
+    compileOnly("com.comphenix.protocol:ProtocolLib:4.7.0")
     compileOnly("me.clip:placeholderapi:2.10.9")
     compileOnly("be.maximvdw:MVdWPlaceholderAPI:3.1.1-SNAPSHOT") {
         exclude("org.spigotmc")

--- a/src/main/java/dev/jaqobb/messageeditor/MessageEditorPlugin.java
+++ b/src/main/java/dev/jaqobb/messageeditor/MessageEditorPlugin.java
@@ -144,15 +144,15 @@ public final class MessageEditorPlugin extends JavaPlugin {
         pluginManager.registerEvents(new PlayerChatListener(this), this);
         this.getLogger().log(Level.INFO, "Registering packet listeners...");
         ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
-        protocolManager.addPacketListener(new ChatPacketListener(this));
-        protocolManager.addPacketListener(new KickPacketListener(this));
-        protocolManager.addPacketListener(new DisconnectPacketListener(this));
-        protocolManager.addPacketListener(new BossBarPacketListener(this));
-        protocolManager.addPacketListener(new ScoreboardTitlePacketListener(this));
-        protocolManager.addPacketListener(new ScoreboardEntryPacketListener(this));
-        protocolManager.addPacketListener(new InventoryTitlePacketListener(this));
-        protocolManager.addPacketListener(new InventoryItemsPacketListener(this));
-        protocolManager.addPacketListener(new EntityNamePacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.chat")) protocolManager.addPacketListener(new ChatPacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.kick")) protocolManager.addPacketListener(new KickPacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.disconnect")) protocolManager.addPacketListener(new DisconnectPacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.bossbar")) protocolManager.addPacketListener(new BossBarPacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.scoreboard-title")) protocolManager.addPacketListener(new ScoreboardTitlePacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.scoreboard-entry")) protocolManager.addPacketListener(new ScoreboardEntryPacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.inventory-title")) protocolManager.addPacketListener(new InventoryTitlePacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.inventory-item")) protocolManager.addPacketListener(new InventoryItemsPacketListener(this));
+        if(getConfig().getBoolean("packet-listeners.entity-name")) protocolManager.addPacketListener(new EntityNamePacketListener(this));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/dev/jaqobb/messageeditor/MessageEditorPlugin.java
+++ b/src/main/java/dev/jaqobb/messageeditor/MessageEditorPlugin.java
@@ -144,15 +144,33 @@ public final class MessageEditorPlugin extends JavaPlugin {
         pluginManager.registerEvents(new PlayerChatListener(this), this);
         this.getLogger().log(Level.INFO, "Registering packet listeners...");
         ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
-        if(getConfig().getBoolean("packet-listeners.chat")) protocolManager.addPacketListener(new ChatPacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.kick")) protocolManager.addPacketListener(new KickPacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.disconnect")) protocolManager.addPacketListener(new DisconnectPacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.bossbar")) protocolManager.addPacketListener(new BossBarPacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.scoreboard-title")) protocolManager.addPacketListener(new ScoreboardTitlePacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.scoreboard-entry")) protocolManager.addPacketListener(new ScoreboardEntryPacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.inventory-title")) protocolManager.addPacketListener(new InventoryTitlePacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.inventory-item")) protocolManager.addPacketListener(new InventoryItemsPacketListener(this));
-        if(getConfig().getBoolean("packet-listeners.entity-name")) protocolManager.addPacketListener(new EntityNamePacketListener(this));
+        if(this.getConfig().getBoolean("packet-listeners.chat", true)) {
+            protocolManager.addPacketListener(new ChatPacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.kick", true)) {
+            protocolManager.addPacketListener(new KickPacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.disconnect", true)) {
+            protocolManager.addPacketListener(new DisconnectPacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.bossbar", true)) {
+            protocolManager.addPacketListener(new BossBarPacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.scoreboard-title", true)) {
+            protocolManager.addPacketListener(new ScoreboardTitlePacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.scoreboard-entry", true)) {
+            protocolManager.addPacketListener(new ScoreboardEntryPacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.inventory-title", true)) {
+            protocolManager.addPacketListener(new InventoryTitlePacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.inventory-item", true)) {
+            protocolManager.addPacketListener(new InventoryItemsPacketListener(this));
+        }
+        if(this.getConfig().getBoolean("packet-listeners.entity-name", true)) {
+            protocolManager.addPacketListener(new EntityNamePacketListener(this));
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/dev/jaqobb/messageeditor/util/MessageUtils.java
+++ b/src/main/java/dev/jaqobb/messageeditor/util/MessageUtils.java
@@ -143,7 +143,7 @@ public final class MessageUtils {
             if (messageIndex == message.length() - 1) {
                 makeMessageComponent = true;
                 messagePart += messageCharacter;
-            } else if (messageCharacter != '§') {
+            } else if (messageCharacter != "§".charAt(0)) {
                 messagePart += messageCharacter;
             } else {
                 char messageHexColorCharacter = message.charAt(messageIndex + 1);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,6 +6,20 @@ update:
 # Whether special hover and click events should be attached to chat messages.
 attach-special-hover-and-click-events: true
 
+# Enabled packet listeners
+# Disable unused contexts to save resources
+# NOTE: Below listeners require a server restart for changes to take effect
+packet-listeners:
+  chat: true
+  kick: true
+  disconnect: true
+  bossbar: true
+  scoreboard-title: true
+  scoreboard-entry: true
+  inventory-title: true
+  inventory-item: true
+  entity-name: true
+
 # Messages that should be edited.
 # For more in-depth tutorial check here:
 # https://github.com/jaqobb/message-editor#usage


### PR DESCRIPTION
I noticed the plugin can take up a fair amount of resources when all the packet listeners are running. As someone who mainly only uses the chat packet listener, I felt like an option to disable the unused listeners would be beneficial for performance :)